### PR TITLE
Fix: Unable to remove unsupported field when inside a repeater or custom component

### DIFF
--- a/assets/js/acf_yoast.js
+++ b/assets/js/acf_yoast.js
@@ -21,6 +21,8 @@
         this.pluginName = 'acfPlugin';
     };
 
+    $.fn.reverse = Array.prototype.reverse;
+
     /**
      * Set's the field content to use in the analysis
      *
@@ -94,15 +96,20 @@
       var parentContent = this.content;
       if ($parents.length > 0) {
         // loop through the parents, in reverse order (top-level elements first)
-        $parents.get().reverse().forEach(function(element) {
-          var $parent = $(element);
+        $parents.reverse().each(function() {
+          var $parent = $(this);
           // parent is either a row/layout (get the id) or a field (get the key)
           var id = $parent.is('[data-id]') ? $parent.attr('data-id') : $parent.attr('data-key');
           parentContent = parentContent[id];
+          if (parentContent === undefined) {
+            return false;
+          }
         });
       }
-      delete parentContent[$el.attr('data-id')];
-      YoastSEO.app.pluginReloaded(this.pluginName);
+      if (parentContent !== undefined) {
+        delete parentContent[$el.attr('data-id')];
+        YoastSEO.app.pluginReloaded(this.pluginName);
+      }
     };
 
     /**


### PR DESCRIPTION
A JavaScript error occurred when removing an unsupported element,
because the ``parentContent`` was undefined. This problem only occurred
when the repeater or flexible content field had only unsupported
elements.
Solution: check if the ``parentContent`` is undefined before trying to
delete one of its properties.
Add this check also in the loop, for nested repeaters and/or flexible
content fields.
It is not possible to break out of a JavaScript ``forEach()``-function,
so use the jQuery ``.each()`` instead. Add support for the
``reverse()``-function on a jQuery array.

This fixes issue #10.